### PR TITLE
Fixes terminal jumping to secondary monitor

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -366,6 +366,8 @@ const DropDownTerminalExtension = new Lang.Class({
             this._toggleOnBusNameAppearance = true;
             this._forkChild();
         }
+        
+        this._updateWindowGeometry();
 
         // the bus proxy might not be ready, in this case we will be called later once the bus name appears
         if (this._busProxy !== null) {


### PR DESCRIPTION
This fixes the issue described in bug #45 (and to a certain degree the one in #50).

Background: I usually have a monitor configuration with an external monitor being the primary one and my laptop being the secondary one. The laptop is arranged on the left, and aligned with the display bottom to the bottom of the primary display. The external (primary) display has a higher pixel height than the laptop (secondary) display.

The current implementation yielded that the animation started at the primary display and then jumped to the secondary one (as described in #45). What is really annoying is that due to the different heights the top of the terminal was always being cut off.

The proposed fix forces another update to the window geometry, what resolves my problem, as the terminal is keep on the screen that contains the top panel.
