### PR TITLE
Call SetGeometry with `y - panelBox.height` instead of `y`.

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -421,7 +421,11 @@ const DropDownTerminalExtension = new Lang.Class({
 
         // applies the change dynamically if the terminal is already spawn
         if (this._busProxy !== null && this._windowHeight !== null) {
-            this._busProxy.SetGeometryRemote(this._windowX, this._windowY, this._windowWidth, this._windowHeight);
+            if (SHELL_VERSION < 3.14) {
+                this._busProxy.SetGeometryRemote(this._windowX, this._windowY, this._windowWidth, this._windowHeight);
+            } else {
+                this._busProxy.SetGeometryRemote(this._windowX, this._windowY - panelBox.height, this._windowWidth, this._windowHeight);
+            }
         }
 
         if (this._windowActor != null) {
@@ -619,7 +623,11 @@ const DropDownTerminalExtension = new Lang.Class({
 
         // applies the geometry if applicable
         if (this._windowHeight !== null) {
-            this._busProxy.SetGeometrySync(this._windowX, this._windowY, this._windowWidth, this._windowHeight);
+            if (SHELL_VERSION < 3.14) {
+                this._busProxy.SetGeometrySync(this._windowX, this._windowY, this._windowWidth, this._windowHeight);
+            } else {
+                this._busProxy.SetGeometrySync(this._windowX, this._windowY - Main.layoutManager.panelBox.height, this._windowWidth, this._windowHeight);
+            }
         }
 
         // initial toggling if explicitely asked to, since we we can also be called on a shell restart


### PR DESCRIPTION
This should fix #84.

Apparently `move` of `Gtk.Window` and `set_position` of `MetaWindowActor` use different y origins since gnome 3.14.
