### PR TITLE
Make terminal opacity configurable.

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/prefs.gtkbuilder
+++ b/drop-down-terminal@gs-extensions.zzrough.org/prefs.gtkbuilder
@@ -332,7 +332,7 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
               <object class="GtkTable" id="table3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="n_rows">6</property>
+                <property name="n_rows">7</property>
                 <property name="n_columns">4</property>
                 <property name="column_spacing">6</property>
                 <property name="row_spacing">6</property>
@@ -358,8 +358,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                     <property name="label" translatable="yes">Height</property>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options"/>
                   </packing>
@@ -379,8 +379,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options"/>
                   </packing>
@@ -402,8 +402,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                   <packing>
                     <property name="left_attach">2</property>
                     <property name="right_attach">3</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="x_options"/>
                     <property name="y_options"/>
                   </packing>
@@ -416,8 +416,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                   <packing>
                     <property name="left_attach">3</property>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="y_options"/>
                   </packing>
                 </child>
@@ -427,8 +427,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                     <property name="can_focus">False</property>
                   </object>
                   <packing>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="top_attach">6</property>
+                    <property name="bottom_attach">7</property>
                     <property name="x_options"/>
                     <property name="y_options"/>
                   </packing>
@@ -444,8 +444,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="top_attach">6</property>
+                    <property name="bottom_attach">7</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options"/>
                   </packing>
@@ -460,8 +460,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                   </object>
                   <packing>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="y_options"/>
                   </packing>
                 </child>
@@ -471,8 +471,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                     <property name="can_focus">False</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
                     <property name="x_options"/>
                     <property name="y_options"/>
                   </packing>
@@ -490,8 +490,8 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options"/>
                   </packing>
@@ -522,6 +522,48 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                     <property name="top_attach">1</property>
                     <property name="bottom_attach">2</property>
                     <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label14">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="xpad">2</property>
+                    <property name="label" translatable="yes">Opacity</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label15">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">3</property>
+                    <property name="right_attach">4</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="transparency-level">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="climb_rate">2.2351741811588166e-10</property>
+                    <property name="numeric">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
                   </packing>
                 </child>
               </object>

--- a/drop-down-terminal@gs-extensions.zzrough.org/prefs.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/prefs.js
@@ -33,6 +33,7 @@ const ENABLE_ANIMATION_SETTING_KEY = "enable-animation";
 const TRANSPARENT_TERMINAL_SETTING_KEY = "transparent-terminal";
 const SCROLLBAR_VISIBLE_SETTING_KEY = "scrollbar-visible";
 const TERMINAL_HEIGHT_SETTING_KEY = "terminal-height";
+const TRANSPARENCY_LEVEL_SETTING_KEY = "transparency-level";
 const SHORTCUT_TYPE_SETTING_KEY = "shortcut-type";
 const OTHER_SHORTCUT_SETTING_KEY = "other-shortcut";
 const REAL_SHORTCUT_SETTING_KEY = "real-shortcut";
@@ -81,6 +82,7 @@ const DropDownTerminalSettingsWidget = new GObject.Class({
             let scrollbarVisibleCheckButton = builder.get_object("scrollbar-visible-checkbutton");
             let terminalHeightEntry = builder.get_object("terminal-height-entry");
             let terminalHeightResetButton = builder.get_object("terminal-height-reset-button");
+            let transparencyLevelSpinner = builder.get_object("transparency-level");
             let defaultShortcutRadioButton = builder.get_object("default-shortcut-radiobutton");
             let enableToggleOnScrollCheckButton = builder.get_object("enable-toggle-on-scroll-checkbutton");
             this._otherShortcutRadioButton = builder.get_object("other-shortcut-radiobutton");
@@ -109,6 +111,17 @@ const DropDownTerminalSettingsWidget = new GObject.Class({
                 terminalHeightEntry["secondary-icon-name"] = valid ? null : "dialog-warning-symbolic";
                 terminalHeightEntry["secondary-icon-tooltip-text"] = valid ? null : _("Invalid syntax or range");
             }));
+
+            // init transparencyLevelSpinner
+            transparencyLevelSpinner.set_range(0,100);
+            transparencyLevelSpinner.set_sensitive(true);
+            transparencyLevelSpinner.set_value(this._settings.get_uint(TRANSPARENCY_LEVEL_SETTING_KEY));
+            transparencyLevelSpinner.set_increments(1, 10);
+            transparencyLevelSpinner.connect('value-changed', Lang.bind(this, function(button){
+                let s = button.get_value_as_int();
+                this._settings.set_uint(TRANSPARENCY_LEVEL_SETTING_KEY, s);
+            }));
+	
 
             // configure the tree view column and creates the unique row of the model
             this._configureOtherShortcutTreeView(this._otherShortcutTreeView);


### PR DESCRIPTION
I've added configuration options to the preferences dialogue to configure the terminal opacity using a number spinner. I edited prefs.gtkbuilder with glade and it made a couple of extra changes to the file, let me know if that is a problem.