### PR TITLE
Fix keybindings in Gnome Shell 3.16

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -459,7 +459,11 @@ const DropDownTerminalExtension = new Lang.Class({
     },
 
     _bindShortcut: function() {
-        if (Main.wm.addKeybinding && Shell.KeyBindingMode) // introduced in 3.7.5
+        if (Main.wm.addKeybinding && Shell.ActionMode) // introduced in 3.16
+            Main.wm.addKeybinding(REAL_SHORTCUT_SETTING_KEY, this._settings, Meta.KeyBindingFlags.NONE,
+                                  Shell.ActionMode.NORMAL | Shell.ActionMode.MESSAGE_TRAY,
+                                  Lang.bind(this, this._toggle));
+        else if (Main.wm.addKeybinding && Shell.KeyBindingMode) // introduced in 3.7.5
             Main.wm.addKeybinding(REAL_SHORTCUT_SETTING_KEY, this._settings, Meta.KeyBindingFlags.NONE,
                                   Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY,
                                   Lang.bind(this, this._toggle));


### PR DESCRIPTION
I fixed the extension to work in Gnome Shell 3.16 by adding a branch in `DropDownTerminal._bindShortcut()` to account for the `Shell.KeybindingMode` -> `Shell.ActionMode` name change.