### PR TITLE
gnome-shell 3.16 renames Shell.KeyBindingMode to Shell.ActionMode

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -459,7 +459,11 @@ const DropDownTerminalExtension = new Lang.Class({
     },
 
     _bindShortcut: function() {
-        if (Main.wm.addKeybinding && Shell.KeyBindingMode) // introduced in 3.7.5
+        if (Main.wm.addKeybinding && Shell.ActionMode) // introdued in 3.15.3
+            Main.wm.addKeybinding(REAL_SHORTCUT_SETTING_KEY, this._settings, Meta.KeyBindingFlags.NONE,
+                                  Shell.ActionMode.NORMAL | Shell.ActionMode.MESSAGE_TRAY,
+                                  Lang.bind(this, this._toggle));
+        else if (Main.wm.addKeybinding && Shell.KeyBindingMode) // introduced in 3.7.5
             Main.wm.addKeybinding(REAL_SHORTCUT_SETTING_KEY, this._settings, Meta.KeyBindingFlags.NONE,
                                   Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY,
                                   Lang.bind(this, this._toggle));


### PR DESCRIPTION
See https://git.gnome.org/browse/gnome-shell/commit/?id=e0eebc90e024481a60d41fdd36606a9ff1bb3b8d
This patch makes drop-down-terminal work with gnome-shell 3.15.3+