### PR TITLE
Sets the x position and width equal to the viewport

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -435,9 +435,10 @@ const DropDownTerminalExtension = new Lang.Class({
     _updateWindowGeometry: function() {
         // computes the window geometry except the height
         let panelBox = Main.layoutManager.panelBox;
-        this._windowX = panelBox.x;
+        let legacyTray = Main.legacyTray.actor;
+        this._windowX = panelBox.x + legacyTray.x;
         this._windowY = Math.max(panelBox.y + panelBox.height, 0);
-        this._windowWidth = panelBox.width;
+        this._windowWidth = legacyTray.width;
 
         // computes and keep the window height for use when the terminal will be spawn (if it is not already)
         let heightSpec = this._settings.get_string(TERMINAL_HEIGHT_SETTING_KEY);


### PR DESCRIPTION
Some extensions (e.g. dash to dock) occupy space on the left or right side of the screen, which makes the terminal overlap with these elements.

With this PR, the width an x position of the terminal is set to the same as the ~~top panel~~ viewport instead of the panelBox.

![terminal-dock](https://cloud.githubusercontent.com/assets/2951180/7107599/1092dce4-e16a-11e4-9aad-e9c3ec4a9ef9.png)

This of course also still works without the dock.

Should fix #43 and #61.
