### PR TITLE
Use DOCK for window type instead of DROPDOWN_MENU

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -451,11 +451,7 @@ const DropDownTerminalExtension = new Lang.Class({
 
         // applies the change dynamically if the terminal is already spawn
         if (this._busProxy !== null && this._windowHeight !== null) {
-            if (SHELL_VERSION < 3.14) {
-                this._busProxy.SetGeometryRemote(this._windowX, this._windowY, this._windowWidth, this._windowHeight);
-            } else {
-                this._busProxy.SetGeometryRemote(this._windowX, this._windowY - panelBox.height, this._windowWidth, this._windowHeight);
-            }
+            this._busProxy.SetGeometryRemote(this._windowX, this._windowY, this._windowWidth, this._windowHeight);
         }
 
         if (this._windowActor != null) {

--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -329,7 +329,7 @@ const DropDownTerminal = new Lang.Class({
         window.set_accept_focus(true);
         window.set_deletable(false);
         window.stick();
-        window.set_type_hint(Gdk.WindowTypeHint.DROPDOWN_MENU);
+        window.set_type_hint(Gdk.WindowTypeHint.DOCK);
         window.set_visual(screen.get_rgba_visual());
         window.connect("delete-event", function() { window.hide(); return true; });
         window.connect("destroy", Gtk.main_quit);


### PR DESCRIPTION
It seems that DROPDOWN_MENU is styles a little magically by gnome-shell as of v3.18.0
and switching to the DOCK type negates that.  It also seems to not require us to
subtract the panel box height from the window Y position.

Fixes #117