### PR TITLE
Close on EOF, like most terminals

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -315,7 +315,7 @@ const DropDownTerminal = new Lang.Class({
         }
 
         terminal.set_encoding("UTF-8");
-        terminal.connect("eof", Lang.bind(this, this._forkUserShell));
+        terminal.connect("eof", Lang.bind(this, this.Toggle));
         terminal.connect("child-exited", Lang.bind(this, this._forkUserShell));
         terminal.connect("button-release-event", Lang.bind(this, this._terminalButtonReleased));
         terminal.connect("button-press-event", Lang.bind(this, this._terminalButtonPressed));


### PR DESCRIPTION
Hi,

I tend to close terminals with Ctrl^D, and I expect the drop down to go away when the shell exits.
I do not know if this is the best way of implementing it, but it's working for me.

cheers