### PR TITLE
Fix and improve transparency

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -456,6 +456,11 @@ const DropDownTerminal = new Lang.Class({
             this._terminal.set_color_background(bgColor);
         }
 
+        // Note: if the terminal widget uses transparency the window widget has to be 100% transparent.
+        //       setting an invisble background colour is better than setting the opcaity, because changing
+        //       the opcaity also affects all child widgets
+        this._window.override_background_color(Gtk.StateType.NORMAL, isTransparent ? new Gdk.RGBA() : null);
+
         if (this._terminalScrollbar.set_opacity) { // 3.7.10+
             // starting from 3.7.10, all gtk widgets can have their opacity changed
             // https://git.gnome.org/browse/gtk+/commit/?id=e12d3cea4751435556f6d122be9033a33576895c

--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -450,6 +450,9 @@ const DropDownTerminal = new Lang.Class({
             this._terminal.set_color_foreground(fgColor);
         }
 
+        // Note: by applying the transparency only to the background colour of the terminal, the text stays
+        //       readable in any case
+        bgColor.alpha = isTransparent ? transparencyLevel : bgColor.alpha;
         if (this._terminal.set_color_background_rgba) { // removed in vte 0.38
             this._terminal.set_color_background_rgba(bgColor);
         } else {
@@ -461,28 +464,8 @@ const DropDownTerminal = new Lang.Class({
         //       the opcaity also affects all child widgets
         this._window.override_background_color(Gtk.StateType.NORMAL, isTransparent ? new Gdk.RGBA() : null);
 
-        if (this._terminalScrollbar.set_opacity) { // 3.7.10+
-            // starting from 3.7.10, all gtk widgets can have their opacity changed
-            // https://git.gnome.org/browse/gtk+/commit/?id=e12d3cea4751435556f6d122be9033a33576895c
-            this._window.opacity = isTransparent ? 0.999 : 1.0;
-
-            this._terminal.opacity = isTransparent ? transparencyLevel : 1.0;
-
-            // FIXME: not updating after setting change from (transparent to non-transparent)
-            this._terminal.backgroundOpacity = transparencyLevel;
-            this._terminal.backgroundTransparent = isTransparent;
-
-            this._terminalScrollbar.set_opacity(isTransparent ? transparencyLevel : 1.0);
-        } else {
-            // making the window transparent also makes the font transparent which make it a bit more difficult
-            // to read, but making the terminal transparent prevents the scrollbar from being styled correctly
-            //
-            // we try to do the best we can by using terminal transparency if there is no scrollbar and falling
-            // back to window transparency if there is one
-            this._terminal.set_opacity(((isTransparent && !hasScrollbar) ? transparencyLevel : 1.0) * 0xffff);
-            this._window.set_opacity((isTransparent && hasScrollbar) ? transparencyLevel : 1.0);
-        }
-
+        // Note: since the scrollbar has no children we can use opacity here
+        this._terminalScrollbar.set_opacity(isTransparent ? transparencyLevel : 1.0);
         this._terminalScrollbar.visible = hasScrollbar;
     },
 


### PR DESCRIPTION
Hi,

this pull request fixes an issue I faced when using the drop down terminal with GNOME 3.20 (Arch Linux): The lastest official version does not ensure that the window, in which the terminal widget is placed, is transparent. This might break transparency (as in my case), since even though the transparency of the terminal itself is working, the current desktop would be hidden by the non-transarent window. Commit c4621fe fixes this by forcing the window background colour to be transparent when transparency is used.

Apart from that the current implementation seems to use opacity instead of the alpha value of the terminal background. This causes the terminal text to be almost invisible when using low values for transparency. Commit c4621fe improves this behaviour by applying the transparency value only to the alpha channel of the terminal background and the scrollbar. This way the terminal text is visible even with full transparency.

Bai
Torben