### PR TITLE
Update for gnome-shell 3.21.91

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/metadata.json
+++ b/drop-down-terminal@gs-extensions.zzrough.org/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "drop-down-terminal@gs-extensions.zzrough.org",
   "name": "Drop Down Terminal",
   "description": "Drop down terminal toggled by a keystroke (the key above tab by default) for advanced users.",
-  "shell-version": ["3.14", "3.16", "3.18", "3.19.91", "3.19.92", "3.20", "3.21.1", "3.21.2", "3.21.3", "3.21.4"],
+  "shell-version": ["3.14", "3.16", "3.18", "3.19.91", "3.19.92", "3.20", "3.21.1", "3.21.2", "3.21.3", "3.21.4", "3.21.91"],
   "url": "https://github.com/zzrough/gs-extensions-drop-down-terminal"
 }
 


### PR DESCRIPTION
For current Debian Unstable