### PR TITLE
Scale the height of the panel when using relative terminal size

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -803,9 +803,8 @@ const DropDownTerminalExtension = new Lang.Class({
             let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
             if (vertical) {
-                let monitorHeight = Main.layoutManager.primaryMonitor.height / scaleFactor;
-                let panelHeight = Main.layoutManager.panelBox.height;
-                return parseInt((monitorHeight - panelHeight) * value / 100.0);
+                let usableHeight = (Main.layoutManager.primaryMonitor.height - Main.layoutManager.panelBox.height + 1) / scaleFactor;
+                return parseInt(usableHeight * value / 100.0);
             } else {
                 let monitorWidth = Main.layoutManager.primaryMonitor.width / scaleFactor;
                 return parseInt(monitorWidth * value / 100.0);


### PR DESCRIPTION
Previously, the usable height was computed by first scaling the monitor height, and then subtracting the panel height.

This led to a smaller value than required on HiDPI monitors, as the panel height is in non-scaled device pixels. This pull request fixes this issue.