### PR TITLE
fix imports wrt Gtk/Gdk 4.0

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/convenience.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/convenience.js
@@ -18,6 +18,9 @@
 const Lang = imports.lang;
 const MainLoop = imports.mainloop;
 
+imports.gi.versions.Gdk = "3.0";
+imports.gi.versions.Gtk = "3.0";
+
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;

--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -19,6 +19,10 @@ const Lang = imports.lang;
 const Gettext = imports.gettext.domain("drop-down-terminal");
 const Mainloop = imports.mainloop;
 
+imports.gi.versions.Gdk = "3.0";
+imports.gi.versions.GdkX11 = "3.0";
+imports.gi.versions.Gtk = "3.0";
+
 const Clutter = imports.gi.Clutter;
 const Cogl = imports.gi.Cogl;
 const Gdk = imports.gi.Gdk;

--- a/drop-down-terminal@gs-extensions.zzrough.org/prefs.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/prefs.js
@@ -18,6 +18,8 @@
 const Lang = imports.lang;
 const Gettext = imports.gettext.domain('drop-down-terminal');
 
+imports.gi.versions.Gtk = "3.0";
+
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gio = imports.gi.Gio;

--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -16,6 +16,10 @@
 // Author: Stéphane Démurget <stephane.demurget@free.fr>
 const Lang = imports.lang;
 
+imports.gi.versions.Gdk = "3.0";
+imports.gi.versions.GdkX11 = "3.0";
+imports.gi.versions.Gtk = "3.0";
+
 const Pango = imports.gi.Pango;
 const Gdk = imports.gi.Gdk;
 const GdkX11 = imports.gi.GdkX11;


### PR DESCRIPTION
If Gtk-4.0 is installed and import version isn't explicit an error will be thrown.

Most likely to occur with Gtk-4.0 which comes with Gtk, Gdk and GdkX11, but may apply to other libraries which can come with more than one version.