### PR TITLE
position based on workarea instead of screen

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
@@ -483,40 +483,39 @@ const DropDownTerminalExtension = new Lang.Class({
         let panelHeight = Main.layoutManager.panelBox.height;
 
         let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        let screen = global.screen.get_monitor_geometry(global.screen.get_primary_monitor());
-        let bbox = Main.legacyTray ? Main.legacyTray.actor : screen;
-        let x1 = bbox.x / scaleFactor;
-        let y1 = bbox.y / scaleFactor;
-        let screenHeight = bbox.height / scaleFactor;
-        let screenWidth = bbox.width / scaleFactor;
+        let workarea = Main.layoutManager.getWorkAreaForMonitor(global.screen.get_primary_monitor());
+        let x1 = workarea.x / scaleFactor;
+        let y1 = workarea.y / scaleFactor;
+        let screenHeight = workarea.height / scaleFactor;
+        let screenWidth = workarea.width / scaleFactor;
         let x2 = x1 + screenWidth;
         let y2 = y1 + screenHeight;
 
         switch (terminalPosition) {
             case LEFT_EDGE:
                 this._windowX = x1;
-                this._windowY = panelBox.y == y1 ? y1 + panelBox.height: y1;
+                this._windowY = y1;
                 this._windowWidth = this._evaluateSizeSpec(sizeSpec, false);
-                this._windowHeight = panelBox.y == y1 ? screenHeight - panelHeight : screenHeight;
+                this._windowHeight = screenHeight;
                 break;
             case RIGHT_EDGE:
                 let width = this._evaluateSizeSpec(sizeSpec, false);
                 this._windowX = x2 - width;
-                this._windowY = panelBox.y == y1 ? y1 + panelBox.height: y1;
+                this._windowY = y1;
                 this._windowWidth = width;
-                this._windowHeight = panelBox.y == y1 ? screenHeight - panelHeight : screenHeight;
+                this._windowHeight = screenHeight;
                 break;
             case BOTTOM_EDGE:
                 let height = this._evaluateSizeSpec(sizeSpec, true);
                 this._windowX = x1;
-                this._windowY = panelBox.y + panelBox.height == y2 ? y2 - panelBox.height - height: y2 - height;
+                this._windowY = y2 - height;
                 this._windowWidth = screenWidth;
                 this._windowHeight = height;
                 break;
             default:
             case TOP_EDGE:
                 this._windowX = x1;
-                this._windowY = panelBox.y == y1 ? y1 + panelBox.height: y1;
+                this._windowY = y1;
                 this._windowWidth = screenWidth;
                 this._windowHeight = this._evaluateSizeSpec(sizeSpec, true);
                 break;


### PR DESCRIPTION
When positioning based off the screen, certain panels (Dash To Dock for example) end up covering the terminal. This change uses the workarea coordinates instead